### PR TITLE
KNN imputation for data, various adaptations for model training

### DIFF
--- a/R/impute_one.R
+++ b/R/impute_one.R
@@ -1,0 +1,61 @@
+# --- Helper function to impute one variable ---
+impute_one <- function(target_var, df, impute_predictors) {
+
+  # remove taget variable from set of predictors
+  use_impute_predictors <- setdiff(impute_predictors, target_var)
+
+  # Select target + predictors
+  d <- df |>
+    select(all_of(c(target_var, use_impute_predictors))) |>
+    drop_na(all_of(use_impute_predictors))  # drop rows missing predictors
+
+  # Separate complete and incomplete rows
+  d_train <- d |>
+    filter(!is.na(!!sym(target_var)))
+
+  d_missing <- df |>
+    filter(is.na(!!sym(target_var))) |>
+    drop_na(use_impute_predictors)
+
+  if (nrow(d_missing) == 0) return(NULL)  # no rows to impute
+
+  # Recipe: target ~ predictors, with normalization
+  rec <- recipe(as.formula(paste(target_var, "~ .")), data = d_train) |>
+
+    # Role handling
+    update_role(all_of(use_impute_predictors), new_role = "predictor") |>
+    step_normalize(all_predictors())
+
+  # Train control + tuning grid
+  ctrl <- trainControl(method = "cv", number = 5)
+  grid <- expand.grid(k = c(5, 15, 25))
+
+  # Train the KNN model
+  model <- train(
+    rec,
+    data = d_train,
+    method = "knn",
+    trControl = ctrl,
+    tuneGrid = grid
+  )
+
+  message("KNN modelling result:")
+  print(model)
+
+  # Predict missing values
+  preds <- predict(model, newdata = d_missing)
+
+  varnam_filled <- paste0(target_var, "_filled")
+  d_missing[[varnam_filled]] <- preds
+
+  # fill missing values
+  out <- df |>
+    left_join(
+      d_missing |>
+        select(all_of(c("site", "date", varnam_filled))),
+      by = join_by(site, date)
+    ) |>
+    mutate(!!target_var := ifelse(is.na(!!sym(target_var)), !!sym(varnam_filled), !!sym(target_var)))
+
+  return(out)
+}

--- a/R/read_ml_data.R
+++ b/R/read_ml_data.R
@@ -22,7 +22,9 @@ read_ml_data <- function(
       -doy,
       -cluster
     ) |>
-    na.omit()
+    dplyr::mutate(
+      is_flue_drought = as.factor(is_flue_drought)
+    )
 
   if (spatial) {
     ml_df <- ml_df |>
@@ -35,9 +37,6 @@ read_ml_data <- function(
         starts_with("LST")
       )
   }
-
-  # convert factor
-  ml_df$is_flue_drought <- as.factor(ml_df$is_flue_drought)
 
   return(ml_df)
 }

--- a/analysis/03beni_regression_training_LSO.R
+++ b/analysis/03beni_regression_training_LSO.R
@@ -71,6 +71,15 @@ df <- df |>
   )
 
 ## Common training setup -------------------------------------------------------
+# KNN imputation of missing values with the following predictors
+# note: this is used if `df` contains missing values and if air temperature and
+# shortwave radiation (tair, r_sw) are added as predictors from local measurements.
+nd_names <- names(nd_exprs)
+impute_vars <- c(
+  band_names,          # NR_B1 to NR_B7
+  nd_names,            # nd_NR_B1_NR_B2, etc.
+  "tair", "r_sw"       # additional predictors for imputation
+)
 
 # Define recipe
 rec <- recipe(
@@ -79,6 +88,7 @@ rec <- recipe(
   ) |>
   update_role(site, date, new_role = "ID") |>
   step_mutate(!!!nd_exprs) |>
+  step_impute_knn(all_of(impute_vars), neighbors = 5) |>
   step_normalize(all_numeric_predictors()) |>
   step_novel() |>
   step_dummy(vegtype)

--- a/analysis/03beni_regression_training_LSO_caret.R
+++ b/analysis/03beni_regression_training_LSO_caret.R
@@ -31,7 +31,11 @@ df <- read_ml_data(
     NR_B7 = Nadir_Reflectance_Band7,
     LST = LST_Day_1km
   ) |>
-  drop_na(starts_with(any_of("NR_", "LST_")), ends_with(any_of("_era5")))
+  drop_na(
+    starts_with("NR_"),
+    starts_with("LST_"),
+    ends_with("_era5")
+  )
 
 # add vegetation type as predictor
 sites <- df |>
@@ -85,13 +89,12 @@ rec <- recipe(
 
   # Role handling
   update_role(site, date, is_flue_drought, new_role = "ID") |>
-  update_role(all_of(impute_only_vars), new_role = "impute") |>
 
   # Feature engineering
   step_mutate(!!!nd_exprs) |>
 
   # Preprocessing (only model-predictors!)
-  step_normalize(all_numeric_predictors(), -all_of(impute_only_vars)) |>
+  step_normalize(all_numeric_predictors()) |>
   step_novel() |>
   step_dummy(vegtype)
 

--- a/analysis/03beni_regression_training_LSO_caret.R
+++ b/analysis/03beni_regression_training_LSO_caret.R
@@ -1,0 +1,157 @@
+# xgboost and random forest with leave-group of sites-out CV, no initial split, comprehensive hp tuning, alternatively testing Random Forest
+
+# load the ecosystem
+library(caret)
+library(rlang)  # ← required for := and sym()
+library(purrr)
+library(dplyr)
+library(here)
+library(ggplot2)
+library(tictoc)
+library(recipes)
+library(vip)
+# remotes::install_github("geco-bern/rgeco")
+library(rgeco)
+# remotes::install_github("geco-bern/FluxDataKit")
+library(FluxDataKit)
+
+source("R/read_ml_data.R")
+
+## Read data -------------------------------------------------------------------
+df <- read_ml_data(
+  here::here("data/machine_learning_training_data.rds")
+) |>
+  rename(
+    NR_B1 = Nadir_Reflectance_Band1,
+    NR_B2 = Nadir_Reflectance_Band2,
+    NR_B3 = Nadir_Reflectance_Band3,
+    NR_B4 = Nadir_Reflectance_Band4,
+    NR_B5 = Nadir_Reflectance_Band5,
+    NR_B6 = Nadir_Reflectance_Band6,
+    NR_B7 = Nadir_Reflectance_Band7,
+    LST = LST_Day_1km
+  )
+
+# add vegetation type as predictor
+sites <- df |>
+  select(site) |>
+  distinct() |>
+  left_join(
+    fdk_site_info |>
+      select(site = sitename, vegtype = igbp_land_use),
+    by = join_by(site)
+  )
+
+# manually add missing info to site info
+sites$vegtype[which(sites$site == "AR-Vir")] <- "ENF"
+sites$vegtype[which(sites$site == "AU-Ade")] <- "WSA"
+sites$vegtype[which(sites$site == "AU-Fog")] <- "WET"
+sites$vegtype[which(sites$site == "AU-Wom")] <- "EBF"
+sites$vegtype[which(sites$site == "DE-Spw")] <- "WET"
+sites$vegtype[which(sites$site == "DK-NuF")] <- "WET"
+sites$vegtype[which(sites$site == "SN-Dhr")] <- "SAV"
+sites$vegtype[which(sites$site == "US-Wi4")] <- "ENF"
+
+# add vegetation type
+df <- df |>
+  left_join(
+    sites,
+    by = join_by(site)
+  )
+
+## Common training setup -------------------------------------------------------
+# KNN imputation of missing values with the following predictors
+# note: this is used if `df` contains missing values and if air temperature and
+# shortwave radiation (tair, r_sw) are added as predictors from local measurements.
+# construct normalised difference indices
+band_names <- df |>
+  select(starts_with("NR_B")) |>
+  names()
+band_pairs <- combn(band_names, 2, simplify = FALSE)
+
+# Build named list of expressions using set_names()
+nd_exprs <- band_pairs |>
+  map(~ expr((!!sym(.x[1]) - !!sym(.x[2])) / (!!sym(.x[1]) + !!sym(.x[2]) + 1e-8))) |>
+  set_names(map_chr(band_pairs, ~ paste0("nd_", .x[1], "_", .x[2])))
+
+nd_names <- names(nd_exprs)
+
+impute_only_vars <- c("tair", "r_sw")
+predict_only_vars <- c("tair_era5", "r_sw_era5", "pcwd_era5", nd_names)
+impute_vars <- c(impute_only_vars, band_names)
+impute_and_predict_vars <- c(band_names, predict_only_vars)
+
+# Define recipe
+rec <- recipe(
+  flue ~ .,
+  data = df
+) |>
+
+  # Role handling
+  update_role(site, date, is_flue_drought, new_role = "ID") |>
+  update_role(all_of(impute_only_vars), new_role = "impute") |>
+
+  # KNN imputation
+  step_impute_knn(
+    all_of(band_names),
+    impute_with = all_of(impute_vars),
+    neighbors = 5
+    ) |>
+
+  # Feature engineering
+  step_mutate(!!!nd_exprs) |>
+
+  # Preprocessing (only model-predictors!)
+  step_normalize(all_numeric_predictors(), -all_of(impute_only_vars)) |>
+  step_novel() |>
+  step_dummy(vegtype)
+
+# check roles
+summary(rec)
+
+# Cross-validation by site (number of folds corresponds to number of sites) or group of sites
+folds <- caret::groupKFold(
+  df$site,
+  k = 5 # length(unique(df$site))
+  )
+
+traincotrlParams <- caret::trainControl(
+  index = folds,
+  method = "cv",
+  savePredictions = "final"   # predictions on each validation resample are then available as modl$pred$Resample
+)
+
+tune_grid <- expand.grid(
+  .mtry = 3, # c(3, 5, 7),
+  .min.node.size = 15, # c(5, 15, 25),
+  .splitrule = "variance"
+)
+
+model <- train(
+  rec,
+  data            = df,
+  metric          = "RMSE",
+  method          = "ranger",
+  tuneGrid        = tune_grid,
+  trControl       = traincotrlParams,
+  replace         = TRUE,
+  sample.fraction = 0.5,
+  num.trees       = 500,         # to be boosted to 2000 for the final model
+  importance      = "impurity"   # for variable importance analysis, alternative: "permutation"
+)
+
+
+# inspect out-of-sample validation results visually
+preds <- model$pred
+preds$site <- df$site[preds$rowIndex]
+
+out <- rgeco::analyse_modobs2(
+  preds,
+  mod = "pred",
+  obs = "obs",
+  type = "hex",
+  pal = "magma",
+  shortsubtitle = TRUE
+)
+
+out$gg

--- a/analysis/03beni_regression_training_LSO_caret.R
+++ b/analysis/03beni_regression_training_LSO_caret.R
@@ -76,11 +76,6 @@ nd_exprs <- band_pairs |>
 
 nd_names <- names(nd_exprs)
 
-impute_only_vars <- c("tair", "r_sw")
-predict_only_vars <- c("tair_era5", "r_sw_era5", "pcwd_era5", nd_names)
-impute_vars <- c(impute_only_vars, band_names)
-impute_and_predict_vars <- c(band_names, predict_only_vars)
-
 # Define recipe
 rec <- recipe(
   flue ~ .,
@@ -90,13 +85,6 @@ rec <- recipe(
   # Role handling
   update_role(site, date, is_flue_drought, new_role = "ID") |>
   update_role(all_of(impute_only_vars), new_role = "impute") |>
-
-  # KNN imputation
-  step_impute_knn(
-    all_of(band_names),
-    impute_with = all_of(impute_vars),
-    neighbors = 5
-    ) |>
 
   # Feature engineering
   step_mutate(!!!nd_exprs) |>

--- a/analysis/03beni_regression_training_LSO_caret.R
+++ b/analysis/03beni_regression_training_LSO_caret.R
@@ -30,7 +30,8 @@ df <- read_ml_data(
     NR_B6 = Nadir_Reflectance_Band6,
     NR_B7 = Nadir_Reflectance_Band7,
     LST = LST_Day_1km
-  )
+  ) |>
+  drop_na(starts_with(any_of("NR_", "LST_")), ends_with(any_of("_era5")))
 
 # add vegetation type as predictor
 sites <- df |>

--- a/data-raw/02_compose_machine_learning_data.R
+++ b/data-raw/02_compose_machine_learning_data.R
@@ -5,12 +5,20 @@
 
 # load libraries
 library(tidyverse)
+library(FluxDataKit)
+library(VIM)
+library(here)
+library(recipes)
+library(caret)
+library(visdat)
+
+source(here("R/impute_one.R"))
 
 # read in raw data (long format)
-site_data <- readRDS("data/MODIS_reflectance_data.rds")
+site_data <- readRDS(here("data/MODIS_reflectance_data.rds"))
 
 # read in flue data
-flue <- readr::read_csv("data/flue_stocker18nphyt.csv")
+flue <- readr::read_csv(here("data/flue_stocker18nphyt.csv"))
 
 # pivot wider for easier band math
 site_data_wide <- site_data |>
@@ -29,8 +37,13 @@ site_data_wide <- site_data |>
 # merge with flue
 site_data_wide <- left_join(
   flue,
-  site_data_wide
+  site_data_wide,
+  by = join_by(site, date)
   )
+
+# reduce data by missing flue
+site_data_wide <- site_data_wide |>
+  drop_na(flue)
 
 # interpolate missing values and daily
 # data for the full time series
@@ -39,19 +52,80 @@ site_data_wide <- left_join(
 # 2. use long term mean weights in spline based gap filling
 # (see phenocam routine)
 
-# for now do a quick linear interpolation
+# beni: avoided linear interpolation to fill gaps, therefore commented out
+# # for now do a quick linear interpolation
+# site_data_wide <- site_data_wide |>
+#   mutate(
+#     across(
+#       where(is.double),
+#       \(x) zoo::na.approx(x, na.rm = FALSE)
+#       )
+#   )
+
+# join with fluxnet observations from FluxDataKit to add covariates for KNN imputation as part of the modelling workflow
+# xxx: use real data for air temperature and shortwave radiation, to be used as predictors for KNN imputation
 site_data_wide <- site_data_wide |>
   mutate(
-    across(
-      where(is.double),
-      \(x) zoo::na.approx(x, na.rm = FALSE)
-      )
+    tair = rnorm(nrow(site_data_wide)),  # just for demo
+    r_sw = rnorm(nrow(site_data_wide))   # just for demo
+    )
+
+# visdat::vis_miss(site_data_wide, warn_large_data = F)
+
+# perform the KNN imputation here. This should be permissible because
+# - KNN imputation as part of the resampling is too slow.
+# - we're not imputinging missingness caused by the resampling
+# - no structured missingness across sites
+
+## Imputation step 1 -----------------
+# Paticular order of variable imputation because bands 1, 3, 5, and 7 have
+# most gaps.
+vis_miss(site_data_wide, warn_large_data = FALSE)
+df <- site_data_wide
+
+vars_to_impute_1 <- site_data_wide |>
+  select(starts_with("Nadir_") & contains(c("1", "3", "5", "7"))) |>
+  names()
+
+impute_predictors_1 <- site_data_wide |>
+  select(all_of(c("tair", "r_sw")), starts_with("Nadir_") & contains(c("2", "4", "6"))) |>
+  names()
+
+for (target_var in vars_to_impute_1){
+  message(paste0("Imputing ", target_var, " ..."))
+  df <- impute_one(target_var, df, impute_predictors_1)
+}
+
+## Imputation step 2 -----------------
+vars_to_impute_2 <- site_data_wide |>
+  select(starts_with("LST")) |>  # important to start with filling LST as it has the most gaps
+  names()
+
+impute_predictors_2 <- site_data_wide |>
+  select(all_of(c("tair", "r_sw")), starts_with("Nadir_")) |>
+  names()
+
+for (target_var in vars_to_impute_2){
+  message(paste0("Imputing ", target_var, " ..."))
+  df <- impute_one(target_var, df, impute_predictors_2)
+}
+
+vis_miss(df, warn_large_data = FALSE)
+
+# xxx: add ERA5 climate data to be used as model predictors (not for imputation, therefore not from site measurements)
+# extract time series of daily values from tidy ERA5-Land data and join into site_data_wide. Also add potential cumulative
+# water deficit (PCWD) data.
+df <- df |>
+  mutate(
+    tair_era5 = rnorm(nrow(df)),  # just for demo
+    r_sw_era5 = rnorm(nrow(df)),  # just for demo
+    pcwd_era5 = rnorm(nrow(df))   # just for demo
   )
 
 # save the data with the indices and flue values
 # for machine learning training
 saveRDS(
-  site_data_wide,
+  df,
   "data/machine_learning_training_data.rds",
   compress = "xz"
 )

--- a/data-raw/02_compose_machine_learning_data.R
+++ b/data-raw/02_compose_machine_learning_data.R
@@ -111,7 +111,7 @@ for (target_var in vars_to_impute_2){
 }
 
 df <- df |>
-  select(-ends_with("_filled"))
+  select(-ends_with("_filled"), -any_of(c("tair", "r_sw")))
 
 vis_miss(df, warn_large_data = FALSE)
 

--- a/data-raw/02_compose_machine_learning_data.R
+++ b/data-raw/02_compose_machine_learning_data.R
@@ -110,6 +110,9 @@ for (target_var in vars_to_impute_2){
   df <- impute_one(target_var, df, impute_predictors_2)
 }
 
+df <- df |>
+  select(-ends_with("_filled"))
+
 vis_miss(df, warn_large_data = FALSE)
 
 # xxx: add ERA5 climate data to be used as model predictors (not for imputation, therefore not from site measurements)
@@ -126,6 +129,6 @@ df <- df |>
 # for machine learning training
 saveRDS(
   df,
-  "data/machine_learning_training_data.rds",
+  here("data/machine_learning_training_data.rds"),
   compress = "xz"
 )


### PR DESCRIPTION
Adaptations implemented in `analysis/03beni_regression_training_LSO_caret.R` include:

- Leave-group (site)-out CV using `rsample::group_vfold_cv()`
- Extracted results from cross validation for evaluation (instead of evaluating on test data from a split up-front). The latter may be done in addition. Extracting from cross validation evaluation is probably sufficient for confidently measuring model skill since the hyper parameter tuning was not super effective. 
- I do a more extensive hyper parameter tuning. It was minimal before (only one parameter, only 3 samples)
- Included vegetation type as predictor (dummy-encoded). This can be used for upscaling since we have vegetation type maps with global coverage based on the same classes (IGBP) as in the training set.
- Added normalised differences of all band combinations as additional predictors. This didn’t seem to have much impact.
- Implemented random forest instead of xgboost for testing. Note that hyperparameter tuning for xgboost is challenging and requires multiple (manual) iterations, see [here](https://bradleyboehmke.github.io/HOML/gbm.html) (section 12.3.3). We may go to xgboost for the final modelling, but to establish the workflow with predictors and cross-validation, we should achieve satisfactory results also with random forest (which is much simpler to work with).
- Avoided linear interpolation of (extensive) reflectance data gaps in `data-raw/02_compose_machine_learning_data.R`. Instead, I implemented a KNN imputation for bands with most extensive gaps and remove rows with remaining gaps. I also added dummy code for adding variables to be used as predictors for KNN imputation (see ‘xxx’ in script). The imputation instead of linear interpolation clearly improved model performance.
- Re-implemented everything with caret instead of tidymodels. This solved the computation bottleneck (I don’t yet understand it, but tidymodels seems to do things on the order of 10 times slower). Is now in `03beni_regression_training_LSO_caret.R`. 
- Up-sampled cases where flue < 1 to avoid apparent tendency for lots of “false negatives”.

To be done @yousra07 :

- [ ] Do more extensive hyper parameter tuning with random forest, sampling about 12 combinations. I now fixed it to `mtry=3` and `min.node.size=15`.
- [ ] Follow suggestion (in `data-raw/02_compose_machine_learning_data.R`) for additional modelling predictor variables to be extracted from ERA5.

Use xgboost instead of Random Forest, follow hyper parameter search as described [here](https://bradleyboehmke.github.io/HOML/gbm.html) (section 12.3.3).